### PR TITLE
Timeout support.

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strconv"
 	"sync/atomic"
+	"time"
 )
 
 const (
@@ -21,6 +22,8 @@ const (
 
 var (
 	ErrNotFound = errors.New("Not found")
+
+	defaultTimeout = 30 * time.Second
 )
 
 type DockerClient struct {
@@ -40,6 +43,10 @@ func (e Error) Error() string {
 }
 
 func NewDockerClient(daemonUrl string, tlsConfig *tls.Config) (*DockerClient, error) {
+	return NewDockerClientTimeout(daemonUrl, tlsConfig, time.Duration(defaultTimeout))
+}
+
+func NewDockerClientTimeout(daemonUrl string, tlsConfig *tls.Config, timeout time.Duration) (*DockerClient, error) {
 	u, err := url.Parse(daemonUrl)
 	if err != nil {
 		return nil, err
@@ -51,7 +58,7 @@ func NewDockerClient(daemonUrl string, tlsConfig *tls.Config) (*DockerClient, er
 			u.Scheme = "https"
 		}
 	}
-	httpClient := newHTTPClient(u, tlsConfig)
+	httpClient := newHTTPClient(u, tlsConfig, timeout)
 	return &DockerClient{u, httpClient, 0}, nil
 }
 

--- a/utils.go
+++ b/utils.go
@@ -5,22 +5,29 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"time"
 )
 
-func newHTTPClient(u *url.URL, tlsConfig *tls.Config) *http.Client {
+func newHTTPClient(u *url.URL, tlsConfig *tls.Config, timeout time.Duration) *http.Client {
 	httpTransport := &http.Transport{
 		TLSClientConfig: tlsConfig,
 	}
-	if u.Scheme == "unix" {
+
+	switch u.Scheme {
+	default:
+		httpTransport.Dial = func(proto, addr string) (net.Conn, error) {
+			return net.DialTimeout(proto, addr, timeout)
+		}
+	case "unix":
 		socketPath := u.Path
-		unixDial := func(proto string, addr string) (net.Conn, error) {
-			return net.Dial("unix", socketPath)
+		unixDial := func(proto, addr string) (net.Conn, error) {
+			return net.DialTimeout("unix", socketPath, timeout)
 		}
 		httpTransport.Dial = unixDial
 		// Override the main URL object so the HTTP lib won't complain
 		u.Scheme = "http"
 		u.Host = "unix.sock"
+		u.Path = ""
 	}
-	u.Path = ""
 	return &http.Client{Transport: httpTransport}
 }


### PR DESCRIPTION
Added a default timeout of 30 seconds with the option to set a custom
one by using NewDockerClientTimeout().

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
