### PR TITLE
Support pulling from a private registry

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,21 @@
+package dockerclient
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+)
+
+// AuthConfig hold parameters for authenticating with the docker registry
+type AuthConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Email    string `json:"email,omitempty"`
+}
+
+// encode the auth configuration struct into base64 for the X-Registry-Auth header
+func (c *AuthConfig) encode() string {
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(c)
+	return base64.URLEncoding.EncodeToString(buf.Bytes())
+}

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,15 @@
+package dockerclient
+
+import (
+	"testing"
+)
+
+func TestAuthEncode(t *testing.T) {
+	a := AuthConfig{Username: "foo", Password: "password", Email: "bar@baz.com"}
+	expected := "eyJ1c2VybmFtZSI6ImZvbyIsInBhc3N3b3JkIjoicGFzc3dvcmQiLCJlbWFpbCI6ImJhckBiYXouY29tIn0K"
+	got := a.encode()
+
+	if expected != got {
+		t.Errorf("testAuthEncode failed. Expected [%s] got [%s]", expected, got)
+	}
+}


### PR DESCRIPTION
If an AuthConfig struct is supplied to PullImage it will be encoded and sent via the X-Registry-Auth header.

doRequest now takes an map of headers to add to the request.
PullImage now takes an optional AuthConfig
Added AuthConfig struct and test.
