### PR TITLE
Update readme with working example based on recent api changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ func main() {
 	docker, _ := dockerclient.NewDockerClient("unix:///var/run/docker.sock", nil)
 
 	// Get only running containers
-	containers, err := docker.ListContainers(false)
+	containers, err := docker.ListContainers(false, false, "")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -40,15 +40,21 @@ func main() {
 		log.Println(info)
 	}
 
+	// Pull image
+	err = docker.PullImage("ubuntu:12.04", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// Create a container
 	containerConfig := &dockerclient.ContainerConfig{Image: "ubuntu:12.04", Cmd: []string{"bash"}}
-	containerId, err := docker.CreateContainer(containerConfig)
+	containerId, err := docker.CreateContainer(containerConfig, "")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Start the container
-	err = docker.StartContainer(containerId)
+	err = docker.StartContainer(containerId, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Example in readme now works with latest code.
Added a PullImage call to ensure the whole example will run, even if the ubuntu:12.04 image is not present. PullImage reflects the change in #47 so it should probably be merged first.
