### PR TITLE
Added test to prevent not updating interface/mock/dockerclient

### DIFF
--- a/dockerclient_test.go
+++ b/dockerclient_test.go
@@ -3,6 +3,7 @@ package dockerclient
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -121,5 +122,14 @@ func TestContainerLogs(t *testing.T) {
 		if !strings.HasSuffix(line, expectedSuffix) {
 			t.Fatalf("expected stderr log line \"%s\" to end with \"%s\"", line, expectedSuffix)
 		}
+	}
+}
+
+func TestDockerClientInterface(t *testing.T) {
+	iface := reflect.TypeOf((*Client)(nil)).Elem()
+	test := testDockerClient(t)
+
+	if !reflect.TypeOf(test).Implements(iface) {
+		t.Fatalf("DockerClient does not implement the Client interface")
 	}
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -1,6 +1,7 @@
 package dockerclient
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -17,4 +18,13 @@ func TestMock(t *testing.T) {
 	}
 
 	mock.Mock.AssertExpectations(t)
+}
+
+func TestMockInterface(t *testing.T) {
+	iface := reflect.TypeOf((*Client)(nil)).Elem()
+	mock := NewMockClient()
+
+	if !reflect.TypeOf(mock).Implements(iface) {
+		t.Fatalf("Mock does not implement the Client interface")
+	}
 }


### PR DESCRIPTION
Test enforces that mock and dockerclient always implement the Client interface.
