### PR TITLE
support for streaming stats

### DIFF
--- a/examples/stats/stats.go
+++ b/examples/stats/stats.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"github.com/samalba/dockerclient"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func statCallback(id string, stat *dockerclient.Stats, ec chan error, args ...interface{}) {
+	log.Println(stat)
+}
+
+func waitForInterrupt() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+	for _ = range sigChan {
+		os.Exit(0)
+	}
+}
+
+func main() {
+	docker, err := dockerclient.NewDockerClient(os.Getenv("DOCKER_HOST"), nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	containerConfig := &dockerclient.ContainerConfig{Image: "busybox", Cmd: []string{"sh"}}
+	containerId, err := docker.CreateContainer(containerConfig, "")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Start the container
+	err = docker.StartContainer(containerId, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	docker.StartMonitorStats(containerId, statCallback, nil)
+
+	waitForInterrupt()
+}

--- a/interface.go
+++ b/interface.go
@@ -6,6 +6,8 @@ import (
 
 type Callback func(*Event, chan error, ...interface{})
 
+type StatCallback func(string, *Stats, chan error, ...interface{})
+
 type Client interface {
 	Info() (*Info, error)
 	ListContainers(all, size bool, filters string) ([]Container, error)
@@ -19,6 +21,8 @@ type Client interface {
 	KillContainer(id, signal string) error
 	StartMonitorEvents(cb Callback, ec chan error, args ...interface{})
 	StopAllMonitorEvents()
+	StartMonitorStats(id string, cb StatCallback, ec chan error, args ...interface{})
+	StopAllMonitorStats()
 	Version() (*Version, error)
 	PullImage(name string, auth *AuthConfig) error
 	RemoveContainer(id string, force, volumes bool) error

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -68,6 +68,14 @@ func (client *MockClient) StopAllMonitorEvents() {
 	client.Mock.Called()
 }
 
+func (client *MockClient) StartMonitorStats(cb dockerclient.StatCallback, ec chan error, args ...interface{}) {
+	client.Mock.Called(cb, ec, args)
+}
+
+func (client *MockClient) StopAllMonitorStats() {
+	client.Mock.Called()
+}
+
 func (client *MockClient) Version() (*dockerclient.Version, error) {
 	args := client.Mock.Called()
 	return args.Get(0).(*dockerclient.Version), args.Error(1)

--- a/types.go
+++ b/types.go
@@ -171,3 +171,80 @@ type ImageDelete struct {
 	Deleted  string
 	Untagged string
 }
+
+// The following are types for the API stats endpoint
+type ThrottlingData struct {
+	// Number of periods with throttling active
+	Periods uint64 `json:"periods"`
+	// Number of periods when the container hit its throttling limit.
+	ThrottledPeriods uint64 `json:"throttled_periods"`
+	// Aggregate time the container was throttled for in nanoseconds.
+	ThrottledTime uint64 `json:"throttled_time"`
+}
+
+type CpuUsage struct {
+	// Total CPU time consumed.
+	// Units: nanoseconds.
+	TotalUsage uint64 `json:"total_usage"`
+	// Total CPU time consumed per core.
+	// Units: nanoseconds.
+	PercpuUsage []uint64 `json:"percpu_usage"`
+	// Time spent by tasks of the cgroup in kernel mode.
+	// Units: nanoseconds.
+	UsageInKernelmode uint64 `json:"usage_in_kernelmode"`
+	// Time spent by tasks of the cgroup in user mode.
+	// Units: nanoseconds.
+	UsageInUsermode uint64 `json:"usage_in_usermode"`
+}
+
+type CpuStats struct {
+	CpuUsage       CpuUsage       `json:"cpu_usage"`
+	SystemUsage    uint64         `json:"system_cpu_usage"`
+	ThrottlingData ThrottlingData `json:"throttling_data,omitempty"`
+}
+
+type MemoryStats struct {
+	Usage    uint64            `json:"usage"`
+	MaxUsage uint64            `json:"max_usage"`
+	Stats    map[string]uint64 `json:"stats"`
+	Failcnt  uint64            `json:"failcnt"`
+	Limit    uint64            `json:"limit"`
+}
+
+type BlkioStatEntry struct {
+	Major uint64 `json:"major"`
+	Minor uint64 `json:"minor"`
+	Op    string `json:"op"`
+	Value uint64 `json:"value"`
+}
+
+type BlkioStats struct {
+	// number of bytes tranferred to and from the block device
+	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive"`
+	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recursive"`
+	IoQueuedRecursive       []BlkioStatEntry `json:"io_queue_recursive"`
+	IoServiceTimeRecursive  []BlkioStatEntry `json:"io_service_time_recursive"`
+	IoWaitTimeRecursive     []BlkioStatEntry `json:"io_wait_time_recursive"`
+	IoMergedRecursive       []BlkioStatEntry `json:"io_merged_recursive"`
+	IoTimeRecursive         []BlkioStatEntry `json:"io_time_recursive"`
+	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive"`
+}
+
+type Network struct {
+	RxBytes   uint64 `json:"rx_bytes"`
+	RxPackets uint64 `json:"rx_packets"`
+	RxErrors  uint64 `json:"rx_errors"`
+	RxDropped uint64 `json:"rx_dropped"`
+	TxBytes   uint64 `json:"tx_bytes"`
+	TxPackets uint64 `json:"tx_packets"`
+	TxErrors  uint64 `json:"tx_errors"`
+	TxDropped uint64 `json:"tx_dropped"`
+}
+
+type Stats struct {
+	Read        time.Time   `json:"read"`
+	Network     Network     `json:"network,omitempty"`
+	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
+	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
+	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
+}

--- a/types.go
+++ b/types.go
@@ -230,20 +230,19 @@ type BlkioStats struct {
 	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive"`
 }
 
-type Network struct {
-	RxBytes   uint64 `json:"rx_bytes"`
-	RxPackets uint64 `json:"rx_packets"`
-	RxErrors  uint64 `json:"rx_errors"`
-	RxDropped uint64 `json:"rx_dropped"`
-	TxBytes   uint64 `json:"tx_bytes"`
-	TxPackets uint64 `json:"tx_packets"`
-	TxErrors  uint64 `json:"tx_errors"`
-	TxDropped uint64 `json:"tx_dropped"`
-}
-
 type Stats struct {
-	Read        time.Time   `json:"read"`
-	Network     Network     `json:"network,omitempty"`
+	Read    time.Time `json:"read"`
+	Network struct {
+		RxBytes   uint64 `json:"rx_bytes"`
+		RxPackets uint64 `json:"rx_packets"`
+		RxErrors  uint64 `json:"rx_errors"`
+		RxDropped uint64 `json:"rx_dropped"`
+		TxBytes   uint64 `json:"tx_bytes"`
+		TxPackets uint64 `json:"tx_packets"`
+		TxErrors  uint64 `json:"tx_errors"`
+		TxDropped uint64 `json:"tx_dropped"`
+	}
+
 	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`


### PR DESCRIPTION
This adds support for streaming stats using the new Docker stats API.

Example in `examples/stats`.