### PR TITLE
added /containers/:id/changes API support

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -197,6 +197,20 @@ func (client *DockerClient) ContainerLogs(id string, options *LogOptions) (io.Re
 	return resp.Body, nil
 }
 
+func (client *DockerClient) ContainerChanges(id string) ([]ContainerChanges, error) {
+	uri := fmt.Sprintf("/%s/containers/%s/changes", APIVersion, id)
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	changes := []ContainerChanges{}
+	err = json.Unmarshal(data, &changes)
+	if err != nil {
+		return nil, err
+	}
+	return changes, nil
+}
+
 func (client *DockerClient) StartContainer(id string, config *HostConfig) error {
 	data, err := json.Marshal(config)
 	if err != nil {

--- a/dockerclient_test.go
+++ b/dockerclient_test.go
@@ -74,6 +74,18 @@ func TestListContainers(t *testing.T) {
 	assertEqual(t, cnt.SizeRw, int64(0), "")
 }
 
+func TestContainerChanges(t *testing.T) {
+	client := testDockerClient(t)
+	changes, err := client.ContainerChanges("foobar")
+	if err != nil {
+		t.Fatal("cannot get container changes: %s", err)
+	}
+	assertEqual(t, len(changes), 3, "unexpected number of changes")
+	c := changes[0]
+	assertEqual(t, c.Path, "/dev", "unexpected")
+	assertEqual(t, c.Kind, 0, "unexpected")
+}
+
 func TestListContainersWithSize(t *testing.T) {
 	client := testDockerClient(t)
 	containers, err := client.ListContainers(true, true, "")

--- a/engine_mock_test.go
+++ b/engine_mock_test.go
@@ -27,6 +27,7 @@ func init() {
 	r.HandleFunc(baseURL+"/info", handlerGetInfo).Methods("GET")
 	r.HandleFunc(baseURL+"/containers/json", handlerGetContainers).Methods("GET")
 	r.HandleFunc(baseURL+"/containers/{id}/logs", handleContainerLogs).Methods("GET")
+	r.HandleFunc(baseURL+"/containers/{id}/changes", handleContainerChanges).Methods("GET")
 	r.HandleFunc(baseURL+"/containers/{id}/kill", handleContainerKill).Methods("POST")
 	r.HandleFunc(baseURL+"/images/create", handleImagePull).Methods("POST")
 	testHTTPServer = httptest.NewServer(handlerAccessLog(r))
@@ -105,6 +106,25 @@ func handleContainerLogs(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintln(outStream, line)
 		}
 	}
+}
+
+func handleContainerChanges(w http.ResponseWriter, r *http.Request) {
+	writeHeaders(w, 200, "changes")
+	body := `[
+          {
+            "Path": "/dev",
+            "Kind": 0
+          },
+          {
+            "Path": "/dev/kmsg",
+            "Kind": 1
+          },
+          {
+            "Path": "/test",
+            "Kind": 1
+          }
+        ]`
+	w.Write([]byte(body))
 }
 
 func getBoolValue(boolString string) bool {

--- a/interface.go
+++ b/interface.go
@@ -12,6 +12,7 @@ type Client interface {
 	InspectContainer(id string) (*ContainerInfo, error)
 	CreateContainer(config *ContainerConfig, name string) (string, error)
 	ContainerLogs(id string, options *LogOptions) (io.ReadCloser, error)
+	ContainerChanges(id string) ([]ContainerChanges, error)
 	Exec(config *ExecConfig) (string, error)
 	StartContainer(id string, config *HostConfig) error
 	StopContainer(id string, timeout int) error

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -40,6 +40,11 @@ func (client *MockClient) ContainerLogs(id string, options *dockerclient.LogOpti
 	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
+func (client *MockClient) ContainerChanges(id string) (io.ReadCloser, error) {
+	args := client.Mock.Called(id)
+	return args.Get(0).(io.ReadCloser), args.Error(1)
+}
+
 func (client *MockClient) StartContainer(id string, config *dockerclient.HostConfig) error {
 	args := client.Mock.Called(id, config)
 	return args.Error(0)

--- a/types.go
+++ b/types.go
@@ -106,6 +106,11 @@ type ContainerInfo struct {
 	HostConfig     *HostConfig
 }
 
+type ContainerChanges struct {
+	Path string
+	Kind int
+}
+
 type Port struct {
 	IP          string
 	PrivatePort int


### PR DESCRIPTION
Hi.
I've added an API: changes.
https://docs.docker.com/reference/api/docker_remote_api_v1.15/#inspect-changes-on-a-containers-filesystem

Thanks!