### PR TITLE
Add a blocking get stats interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -31,4 +31,5 @@ type Client interface {
 	RemoveImage(name string) ([]*ImageDelete, error)
 	PauseContainer(name string) error
 	UnpauseContainer(name string) error
+	GetStats(id string, statsChan chan Stats, errorChan chan ContainerError, exitChan chan bool)
 }

--- a/types.go
+++ b/types.go
@@ -237,8 +237,9 @@ type BlkioStats struct {
 }
 
 type Stats struct {
-	Read    time.Time `json:"read"`
-	Network struct {
+	ContainerId string
+	Read        time.Time `json:"read"`
+	Network     struct {
 		RxBytes   uint64 `json:"rx_bytes"`
 		RxPackets uint64 `json:"rx_packets"`
 		RxErrors  uint64 `json:"rx_errors"`
@@ -252,4 +253,9 @@ type Stats struct {
 	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`
+}
+
+type ContainerError struct {
+	Error       error
+	ContainerId string
 }


### PR DESCRIPTION
Hi - I am working on an application that consumes the dockerclient api! (woot) Specifically I am working with the stats API. The implementation of the stats API in this library and great and seems well suited for short lived client application. I am writing a daemon that will monitor the stats and have some additional requirements that don't seem to work well with the current implementation.

1. When an error occurs that causes the go routine to exit, I need to know the ```error``` and the container ID that it is related to.
2. I need to be able to ask a _specific_ stats monitor (go routine) to stop politely 
3. I would prefer to use channels over callbacks for ``stat``` processing. 

Thoughts?