### PR TITLE
adding build image functionality

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -19,3 +19,16 @@ func (c *AuthConfig) encode() string {
 	json.NewEncoder(&buf).Encode(c)
 	return base64.URLEncoding.EncodeToString(buf.Bytes())
 }
+
+// ConfigFile holds parameters for authenticating during a BuildImage request
+type ConfigFile struct {
+	Configs  map[string]AuthConfig `json:"configs,omitempty"`
+	rootPath string
+}
+
+// encode the configuration struct into base64 for the X-Registry-Config header
+func (c *ConfigFile) encode() string {
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(c)
+	return base64.URLEncoding.EncodeToString(buf.Bytes())
+}

--- a/dockerclient.go
+++ b/dockerclient.go
@@ -355,16 +355,17 @@ func (client *DockerClient) BuildImage(image BuildImage, config *ConfigFile) err
 
 	buf := new(bytes.Buffer)
 	tw := tar.NewWriter(buf)
-	for k, v := range image.Files {
+	for _, v := range image.Files {
 		hdr := &tar.Header{
-			Name: k,
-			Size: int64(len(v)),
+			Name: v.Name,
+			Size: int64(len(v.Contents)),
+			Mode: v.Mode,
 		}
 		err := tw.WriteHeader(hdr)
 		if err != nil {
 			return err
 		}
-		_, err = tw.Write([]byte(v))
+		_, err = tw.Write(v.Contents)
 		if err != nil {
 			return err
 		}

--- a/interface.go
+++ b/interface.go
@@ -12,6 +12,7 @@ type Client interface {
 	Info() (*Info, error)
 	ListContainers(all, size bool, filters string) ([]Container, error)
 	InspectContainer(id string) (*ContainerInfo, error)
+	BuildImage(image BuildImage, config *ConfigFile) error
 	CreateContainer(config *ContainerConfig, name string) (string, error)
 	ContainerLogs(id string, options *LogOptions) (io.ReadCloser, error)
 	ContainerChanges(id string) ([]*ContainerChanges, error)

--- a/types.go
+++ b/types.go
@@ -158,6 +158,17 @@ type Image struct {
 	VirtualSize int64
 }
 
+type BuildImage struct {
+	Name           string
+	Remote         string
+	DockerfilePath string
+	Files          map[string]string
+	NoCache        bool
+	Pull           bool
+	Remove         bool
+	ForceRemove    bool
+}
+
 type Info struct {
 	ID              string
 	Containers      int64

--- a/types.go
+++ b/types.go
@@ -158,11 +158,17 @@ type Image struct {
 	VirtualSize int64
 }
 
+type File struct {
+	Name     string
+	Contents []byte
+	Mode     int64
+}
+
 type BuildImage struct {
 	Name           string
 	Remote         string
 	DockerfilePath string
-	Files          map[string]string
+	Files          []File
 	NoCache        bool
 	Pull           bool
 	Remove         bool

--- a/types.go
+++ b/types.go
@@ -1,6 +1,9 @@
 package dockerclient
 
-import "time"
+import (
+	"io"
+	"time"
+)
 
 type ContainerConfig struct {
 	Hostname        string
@@ -158,17 +161,11 @@ type Image struct {
 	VirtualSize int64
 }
 
-type File struct {
-	Name     string
-	Contents []byte
-	Mode     int64
-}
-
 type BuildImage struct {
 	Name           string
 	Remote         string
 	DockerfilePath string
-	Files          []File
+	Tarfile        io.Reader
 	NoCache        bool
 	Pull           bool
 	Remove         bool


### PR DESCRIPTION
fixes issue https://github.com/samalba/dockerclient/issues/62

usage:

```
docker, err := dockerclient.NewDockerClient("unix:///var/run/docker.sock", nil)
if err != nil {
	return err
}

image := dockerclient.BuildImage{}
image.Name = name
image.Files = make(map[string]string)
image.Files["Dockerfile"] = "FROM scratch"

config := &dockerclient.ConfigFile{}
config.Configs = make(map[string]dockerclient.AuthConfig)
config.Configs["<uri to quay>"] = auth

err = docker.BuildImage(image, config)
if err != nil {
	return err
}
```