### PR TITLE
add SecurityOpt to HostConfig

### DIFF
--- a/types.go
+++ b/types.go
@@ -43,6 +43,7 @@ type HostConfig struct {
 	Dns             []string
 	DnsSearch       []string
 	VolumesFrom     []string
+	SecurityOpt     []string
 	NetworkMode     string
 	RestartPolicy   RestartPolicy
 }


### PR DESCRIPTION
This is required for starting containers with selinux enabled