### PR TITLE
Exec split start/create and ExecResize

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -277,7 +277,7 @@ func (client *DockerClient) ExecCreate(config *ExecConfig) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	uri := fmt.Sprintf("/containers/%s/exec", config.Container)
+	uri := fmt.Sprintf("/%s/containers/%s/exec", APIVersion, config.Container)
 	resp, err := client.doRequest("POST", uri, data, nil)
 	if err != nil {
 		return "", err
@@ -297,7 +297,7 @@ func (client *DockerClient) ExecStart(id string, config *ExecConfig) error {
 		return err
 	}
 
-	uri := fmt.Sprintf("/exec/%s/start", id)
+	uri := fmt.Sprintf("/%s/exec/%s/start", APIVersion, id)
 	if _, err := client.doRequest("POST", uri, data, nil); err != nil {
 		return err
 	}

--- a/dockerclient.go
+++ b/dockerclient.go
@@ -288,11 +288,6 @@ func (client *DockerClient) ExecCreate(config *ExecConfig) (string, error) {
 	if err = json.Unmarshal(resp, &createExecResp); err != nil {
 		return "", err
 	}
-	uri = fmt.Sprintf("/exec/%s/start", createExecResp.Id)
-	resp, err = client.doRequest("POST", uri, data, nil)
-	if err != nil {
-		return "", err
-	}
 	return createExecResp.Id, nil
 }
 

--- a/interface.go
+++ b/interface.go
@@ -16,7 +16,9 @@ type Client interface {
 	CreateContainer(config *ContainerConfig, name string) (string, error)
 	ContainerLogs(id string, options *LogOptions) (io.ReadCloser, error)
 	ContainerChanges(id string) ([]*ContainerChanges, error)
-	Exec(config *ExecConfig) (string, error)
+	ExecCreate(config *ExecConfig) (string, error)
+	ExecStart(id string, config *ExecConfig) error
+	ExecResize(id string, width, height int) error
 	StartContainer(id string, config *HostConfig) error
 	StopContainer(id string, timeout int) error
 	RestartContainer(id string, timeout int) error

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -141,9 +141,19 @@ func (client *MockClient) UnpauseContainer(name string) error {
 	return args.Error(0)
 }
 
-func (client *MockClient) Exec(config *dockerclient.ExecConfig) (string, error) {
+func (client *MockClient) ExecCreate(config *dockerclient.ExecConfig) (string, error) {
 	args := client.Mock.Called(config)
 	return args.String(0), args.Error(1)
+}
+
+func (client *MockClient) ExecStart(id string, config *dockerclient.ExecConfig) error {
+	args := client.Mock.Called(id, config)
+	return args.Error(0)
+}
+
+func (client *MockClient) ExecResize(id string, width, height int) error {
+	args := client.Mock.Called(id, width, height)
+	return args.Error(0)
 }
 
 func (client *MockClient) RenameContainer(oldName string, newName string) error {


### PR DESCRIPTION
This changes the Exec operation to split out the create and start phases.  This is needed in case you want to do something like hijack the start.

This also adds ExecResize.