### PR TITLE
Push image

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -19,3 +19,16 @@ func (c *AuthConfig) encode() string {
 	json.NewEncoder(&buf).Encode(c)
 	return base64.URLEncoding.EncodeToString(buf.Bytes())
 }
+
+// ConfigFile holds parameters for authenticating during a BuildImage request
+type ConfigFile struct {
+	Configs  map[string]AuthConfig `json:"configs,omitempty"`
+	rootPath string
+}
+
+// encode the configuration struct into base64 for the X-Registry-Config header
+func (c *ConfigFile) encode() string {
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(c)
+	return base64.URLEncoding.EncodeToString(buf.Bytes())
+}

--- a/dockerclient.go
+++ b/dockerclient.go
@@ -397,6 +397,33 @@ func (client *DockerClient) BuildImage(image BuildImage, config *ConfigFile) err
 	return nil
 }
 
+func (client *DockerClient) PushImage(name string, tag string, auth *AuthConfig) error {
+	v := url.Values{}
+	if tag != "" {
+		v.Set("tag", tag)
+	}
+	uri := fmt.Sprintf("/%s/images/%s/push?%s", APIVersion, url.QueryEscape(name), v.Encode())
+	req, err := http.NewRequest("POST", client.URL.String()+uri, nil)
+	if auth != nil {
+		req.Header.Add("X-Registry-Auth", auth.encode())
+	}
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var finalObj map[string]interface{}
+	for decoder := json.NewDecoder(resp.Body); err == nil; err = decoder.Decode(&finalObj) {
+	}
+	if err != io.EOF {
+		return err
+	}
+	if err, ok := finalObj["error"]; ok {
+		return fmt.Errorf("%v", err)
+	}
+	return nil
+}
+
 func (client *DockerClient) PullImage(name string, auth *AuthConfig) error {
 	v := url.Values{}
 	v.Set("fromImage", name)

--- a/interface.go
+++ b/interface.go
@@ -27,6 +27,7 @@ type Client interface {
 	StopAllMonitorStats()
 	Version() (*Version, error)
 	PullImage(name string, auth *AuthConfig) error
+	PushImage(name string, tag string, auth *AuthConfig) error
 	RemoveContainer(id string, force, volumes bool) error
 	ListImages() ([]*Image, error)
 	RemoveImage(name string) ([]*ImageDelete, error)

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -73,8 +73,8 @@ func (client *MockClient) StopAllMonitorEvents() {
 	client.Mock.Called()
 }
 
-func (client *MockClient) StartMonitorStats(cb dockerclient.StatCallback, ec chan error, args ...interface{}) {
-	client.Mock.Called(cb, ec, args)
+func (client *MockClient) StartMonitorStats(id string, cb dockerclient.StatCallback, ec chan error, args ...interface{}) {
+	client.Mock.Called(id, cb, ec, args)
 }
 
 func (client *MockClient) StopAllMonitorStats() {

--- a/types.go
+++ b/types.go
@@ -158,6 +158,17 @@ type Image struct {
 	VirtualSize int64
 }
 
+type BuildImage struct {
+	Name           string
+	Remote         string
+	DockerfilePath string
+	Files          map[string]string
+	NoCache        bool
+	Pull           bool
+	Remove         bool
+	ForceRemove    bool
+}
+
 type Info struct {
 	ID              string
 	Containers      int64


### PR DESCRIPTION
This PR also contains the BuildImage functionality from https://github.com/samalba/dockerclient/pull/85 Merge https://github.com/samalba/dockerclient/pull/85 First to see a better diff.

PushImage will take an image name, tag, and optional authentication configuration and push that image to an image repository e.g. https://quay.io/