### PR TITLE
Add support import

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -97,6 +97,41 @@ func (client *DockerClient) doRequest(method string, path string, body []byte, h
 	return data, nil
 }
 
+func (client *DockerClient) doStreamRequest(method string, path string, in io.Reader, headers map[string]string) (io.ReadCloser, error) {
+	if (method == "POST" || method == "PUT") && in == nil {
+		in = bytes.NewReader([]byte{})
+	}
+	req, err := http.NewRequest(method, client.URL.String()+path, in)
+	if err != nil {
+		return nil, err
+	}
+	if method == "POST" {
+		req.Header.Add("Content-Type", "plain/text")
+	}
+	if headers != nil {
+		for header, value := range headers {
+			req.Header.Add(header, value)
+		}
+	}
+	resp, err := client.HTTPClient.Do(req)
+	if err != nil {
+		if !strings.Contains(err.Error(), "connection refused") && client.TLSConfig == nil {
+			return nil, fmt.Errorf("%v. Are you trying to connect to a TLS-enabled daemon without TLS?", err)
+		}
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		data, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return nil, Error{StatusCode: resp.StatusCode, Status: resp.Status, msg: string(data)}
+	}
+
+	return resp.Body, nil
+}
+
 func (client *DockerClient) Info() (*Info, error) {
 	uri := fmt.Sprintf("/%s/info", APIVersion)
 	data, err := client.doRequest("GET", uri, nil, nil)
@@ -463,4 +498,26 @@ func (client *DockerClient) RenameContainer(oldName string, newName string) erro
 	uri := fmt.Sprintf("/containers/%s/rename?name=%s", oldName, newName)
 	_, err := client.doRequest("POST", uri, nil, nil)
 	return err
+}
+
+func (client *DockerClient) ImportImage(source string, repository string, tag string, tar io.Reader) (io.ReadCloser, error) {
+	var fromSrc string
+	v := &url.Values{}
+	if source == "" {
+		fromSrc = "-"
+	} else {
+		fromSrc = source
+	}
+
+	v.Set("fromSrc", fromSrc)
+	v.Set("repo", repository)
+	if tag != "" {
+		v.Set("tag", tag)
+	}
+
+	var in io.Reader
+	if fromSrc == "-" {
+		in = tar
+	}
+	return client.doStreamRequest("POST", "/images/create?"+v.Encode(), in, nil)
 }

--- a/dockerclient.go
+++ b/dockerclient.go
@@ -82,7 +82,7 @@ func (client *DockerClient) doRequest(method string, path string, body []byte, h
 
 func (client *DockerClient) doStreamRequest(method string, path string, in io.Reader, headers map[string]string) (io.ReadCloser, error) {
 	if (method == "POST" || method == "PUT") && in == nil {
-		in = bytes.NewReader([]byte{})
+		in = bytes.NewReader(nil)
 	}
 	req, err := http.NewRequest(method, client.URL.String()+path, in)
 	if err != nil {

--- a/interface.go
+++ b/interface.go
@@ -34,4 +34,5 @@ type Client interface {
 	PauseContainer(name string) error
 	UnpauseContainer(name string) error
 	RenameContainer(oldName string, newName string) error
+	ImportImage(source string, repository string, tag string, tar io.Reader) (io.ReadCloser, error)
 }

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -135,3 +135,8 @@ func (client *MockClient) RenameContainer(oldName string, newName string) error 
 	args := client.Mock.Called(oldName, newName)
 	return args.Error(0)
 }
+
+func (client *MockClient) ImportImage(source string, repository string, tag string, tar io.Reader) (io.ReadCloser, error) {
+	args := client.Mock.Called(source, repository, tag, tar)
+	return args.Get(0).(io.ReadCloser), args.Error(1)
+}


### PR DESCRIPTION
Implement swarm import (issue: https://github.com/docker/swarm/issues/631), need this interface
Test code:
```
package main

import (
    "github.com/samalba/dockerclient"
    "os"
    "fmt"
    "io/ioutil"
)

func main() {
    // Init the client
    docker, _ := dockerclient.NewDockerClient("unix:///var/run/docker.sock", nil)

    file, _ := os.Open("/home/busybox.tar")
    reader, _ := docker.ImportImage("", "mybusybox", "abc", file)

    data, _ := ioutil.ReadAll(reader)
    fmt.Printf("%s", data)
}
```
Test Result:
```
[root@localhost samalba]# go run test.go 
{"status":"b14b8a22f2e03d1ac7c4dff8ce73fc763ec158dcfbc86fcc9090a205b5e4bc69"}
[root@localhost samalba]# 
[root@localhost samalba]# docker images
REPOSITORY                         TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
mybusybox                          abc                 b14b8a22f2e0        3 seconds ago       2.43 MB
```
Signed-off-by: Xian Chaobo <xianchaobo@huawei.com>