### PR TITLE
Add LogConfig and Ulimits(new in docker 1.6).

### DIFF
--- a/types.go
+++ b/types.go
@@ -46,6 +46,8 @@ type HostConfig struct {
 	SecurityOpt     []string
 	NetworkMode     string
 	RestartPolicy   RestartPolicy
+	Ulimits         []Ulimit
+	LogConfig       LogConfig
 }
 
 type ExecConfig struct {
@@ -255,4 +257,15 @@ type Stats struct {
 	CpuStats     CpuStats     `json:"cpu_stats,omitempty"`
 	MemoryStats  MemoryStats  `json:"memory_stats,omitempty"`
 	BlkioStats   BlkioStats   `json:"blkio_stats,omitempty"`
+}
+
+type Ulimit struct {
+	Name string `json:"name"`
+	Soft uint64 `json:"soft"`
+	Hard uint64 `json:"hard"`
+}
+
+type LogConfig struct {
+	Type   string            `json:"type"`
+	Config map[string]string `json:"config"`
 }


### PR DESCRIPTION
Implement the new feature in docker 1.6

![dockerclient](https://cloud.githubusercontent.com/assets/973197/7389228/97e724fc-ee9e-11e4-9e47-7d8edaf428b9.jpg)

Ulimits - A list of ulimits to be set in the container, specified as { "Name": <name>, "Soft": <soft limit>, "Hard": <hard limit> }, for example: Ulimits: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}

LogConfig - Logging configuration to container, format { "Type": "<driver_name>", "Config": {"key1": "val1"}} Available types:json-file,syslog,none.json-file` logging driver. 

Add two types for HostConfig
