### PR TITLE
update engine_mock_test imports

### DIFF
--- a/engine_mock_test.go
+++ b/engine_mock_test.go
@@ -10,10 +10,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/timeutils"
-	"github.com/docker/docker/utils"
 	"github.com/gorilla/mux"
 )
 
@@ -74,7 +74,7 @@ func handleImagePull(w http.ResponseWriter, r *http.Request) {
 
 func handleContainerLogs(w http.ResponseWriter, r *http.Request) {
 	var outStream, errStream io.Writer
-	outStream = utils.NewWriteFlusher(w)
+	outStream = ioutils.NewWriteFlusher(w)
 
 	// not sure how to test follow
 	if err := r.ParseForm(); err != nil {


### PR DESCRIPTION
I couldn't run tests with a more updated docker/docker because they moved things around a bit. We might want to consider Godeps in the future, but for now I'm just updating the imports.

ping @aluzzardi @vieux @abronan @ehazlett 