### PR TITLE
wait for event handler to complete

### DIFF
--- a/examples/events.go
+++ b/examples/events.go
@@ -12,10 +12,15 @@ func eventCallback(e *dockerclient.Event, ec chan error, args ...interface{}) {
 	log.Println(e)
 }
 
+var (
+	client *dockerclient.DockerClient
+)
+
 func waitForInterrupt() {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	for _ = range sigChan {
+		client.StopAllMonitorEvents()
 		os.Exit(0)
 	}
 }
@@ -26,7 +31,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	docker.StartMonitorEvents(eventCallback, nil)
+	client = docker
+
+	client.StartMonitorEvents(eventCallback, nil)
 
 	waitForInterrupt()
 }


### PR DESCRIPTION
This makes `StopMonitorEvents` block until the handler is finished.