### PR TITLE
StopAllMonitorEvents: Close the channel instead of sending to it to

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -381,7 +381,7 @@ func (client *DockerClient) StartMonitorEvents(cb Callback, ec chan error, args 
 }
 
 func (client *DockerClient) StopAllMonitorEvents() {
-	client.eventStopChan <- struct{}{}
+	close(client.eventStopChan)
 }
 
 func (client *DockerClient) StartMonitorStats(id string, cb StatCallback, ec chan error, args ...interface{}) {


### PR DESCRIPTION
avoid blocking.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>