### PR TITLE
Don't run the events callback in goroutine

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -375,7 +375,7 @@ func (client *DockerClient) StartMonitorEvents(cb Callback, ec chan error, args 
 				ec <- err
 				return
 			}
-			go cb(&e.Event, ec, args...)
+			cb(&e.Event, ec, args...)
 		}
 	}()
 }


### PR DESCRIPTION
Fixes https://github.com/docker/swarm/issues/1006

The variable in the "for" statement is re-used on each iteration.
If we call the callback function in a goroutine, we should create a
local variable before starting the goroutine.

I think the callbacks should not execute concurrently because the Docker
events are sequential.

Signed-off-by: Shijiang Wei <mountkin@gmail.com>