### PR TITLE
Fix failing tests

### DIFF
--- a/engine_mock_test.go
+++ b/engine_mock_test.go
@@ -98,7 +98,7 @@ func handleContainerLogs(w http.ResponseWriter, r *http.Request) {
 	for ; i < 50; i++ {
 		line := fmt.Sprintf("line %d", i)
 		if getBoolValue(r.Form.Get("timestamps")) {
-			l := &jsonlog.JSONLog{Log: line, Created: time.Now()}
+			l := &jsonlog.JSONLog{Log: line, Created: time.Now().UTC()}
 			line = fmt.Sprintf("%s %s", l.Created.Format(timeutils.RFC3339NanoFixed), line)
 		}
 		if i%2 == 0 && stderr {

--- a/interface.go
+++ b/interface.go
@@ -35,7 +35,7 @@ type Client interface {
 	PullImage(name string, auth *AuthConfig) error
 	LoadImage(reader io.Reader) error
 	RemoveContainer(id string, force, volumes bool) error
-	ListImages() ([]*Image, error)
+	ListImages(all bool) ([]*Image, error)
 	RemoveImage(name string) ([]*ImageDelete, error)
 	PauseContainer(name string) error
 	UnpauseContainer(name string) error

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -116,8 +116,8 @@ func (client *MockClient) RemoveContainer(id string, force, volumes bool) error 
 	return args.Error(0)
 }
 
-func (client *MockClient) ListImages() ([]*dockerclient.Image, error) {
-	args := client.Mock.Called()
+func (client *MockClient) ListImages(all bool) ([]*dockerclient.Image, error) {
+	args := client.Mock.Called(all)
 	return args.Get(0).([]*dockerclient.Image), args.Error(1)
 }
 


### PR DESCRIPTION
- TestContainerLogs was failing on machines using non-UTC timezone.
- Update Client/MockClient `ListImages()` signature