### PR TITLE
Implemented the `Wait` function from the Docker Remote API

### DIFF
--- a/dockerclient_test.go
+++ b/dockerclient_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/pkg/stdcopy"
 )
@@ -44,6 +45,26 @@ func TestKillContainer(t *testing.T) {
 	client := testDockerClient(t)
 	if err := client.KillContainer("23132acf2ac", "5"); err != nil {
 		t.Fatal("cannot kill container: %s", err)
+	}
+}
+
+func TestWait(t *testing.T) {
+	client := testDockerClient(t)
+
+	// This provokes an error on the server.
+	select {
+	case wr := <-client.Wait("1234"):
+		assertEqual(t, wr.ExitCode, int(-1), "")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out!")
+	}
+
+	// Valid case.
+	select {
+	case wr := <-client.Wait("valid-id"):
+		assertEqual(t, wr.ExitCode, int(0), "")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out!")
 	}
 }
 

--- a/engine_mock_test.go
+++ b/engine_mock_test.go
@@ -29,6 +29,7 @@ func init() {
 	r.HandleFunc(baseURL+"/containers/{id}/logs", handleContainerLogs).Methods("GET")
 	r.HandleFunc(baseURL+"/containers/{id}/changes", handleContainerChanges).Methods("GET")
 	r.HandleFunc(baseURL+"/containers/{id}/kill", handleContainerKill).Methods("POST")
+	r.HandleFunc(baseURL+"/containers/{id}/wait", handleWait).Methods("POST")
 	r.HandleFunc(baseURL+"/images/create", handleImagePull).Methods("POST")
 	r.HandleFunc(baseURL+"/events", handleEvents).Methods("GET")
 	testHTTPServer = httptest.NewServer(handlerAccessLog(r))
@@ -44,6 +45,15 @@ func handlerAccessLog(handler http.Handler) http.Handler {
 
 func handleContainerKill(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "{%q:%q", "Id", "421373210afd132")
+}
+
+func handleWait(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	if vars["id"] == "valid-id" {
+		fmt.Fprintf(w, `{"StatusCode":0}`)
+	} else {
+		http.Error(w, "failed", 500)
+	}
 }
 
 func handleImagePull(w http.ResponseWriter, r *http.Request) {

--- a/interface.go
+++ b/interface.go
@@ -21,6 +21,7 @@ type Client interface {
 	StopContainer(id string, timeout int) error
 	RestartContainer(id string, timeout int) error
 	KillContainer(id, signal string) error
+	Wait(id string) <-chan WaitResult
 	// MonitorEvents takes options and an optional stop channel, and returns
 	// an EventOrError channel. If an error is ever sent, then no more
 	// events will be sent. If a stop channel is provided, events will stop

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -70,6 +70,11 @@ func (client *MockClient) KillContainer(id, signal string) error {
 	return args.Error(0)
 }
 
+func (client *MockClient) Wait(id string) <-chan dockerclient.WaitResult {
+	args := client.Mock.Called(id)
+	return args.Get(0).(<-chan dockerclient.WaitResult)
+}
+
 func (client *MockClient) MonitorEvents(options *dockerclient.MonitorEventsOptions, stopChan <-chan struct{}) (<-chan dockerclient.EventOrError, error) {
 	args := client.Mock.Called(options, stopChan)
 	return args.Get(0).(<-chan dockerclient.EventOrError), args.Error(1)

--- a/types.go
+++ b/types.go
@@ -324,6 +324,11 @@ type EventOrError struct {
 	Error error
 }
 
+type WaitResult struct {
+	ExitCode int
+	Error    error
+}
+
 type decodingResult struct {
 	result interface{}
 	err    error


### PR DESCRIPTION
This function is meant to be used like this:

```go
select {
case w := <-docker.Wait(id):
        fmt.Printf("Wait! %v\n", w)
case <-time.After(2 * time.Second):
        fmt.Printf("Timed out!\n")
}
```

See: https://docs.docker.com/reference/api/docker_remote_api_v1.19/#wait-a-container