### PR TITLE
List images: support filtering

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -35,7 +35,7 @@ type Client interface {
 	PullImage(name string, auth *AuthConfig) error
 	LoadImage(reader io.Reader) error
 	RemoveContainer(id string, force, volumes bool) error
-	ListImages(all bool) ([]*Image, error)
+	ListImages(all bool, filter *ListFilter) ([]*Image, error)
 	RemoveImage(name string) ([]*ImageDelete, error)
 	PauseContainer(name string) error
 	UnpauseContainer(name string) error

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -116,8 +116,8 @@ func (client *MockClient) RemoveContainer(id string, force, volumes bool) error 
 	return args.Error(0)
 }
 
-func (client *MockClient) ListImages(all bool) ([]*dockerclient.Image, error) {
-	args := client.Mock.Called(all)
+func (client *MockClient) ListImages(all bool, filter *ListFilter) ([]*dockerclient.Image, error) {
+	args := client.Mock.Called(all, filter)
 	return args.Get(0).([]*dockerclient.Image), args.Error(1)
 }
 

--- a/types.go
+++ b/types.go
@@ -437,3 +437,9 @@ type BuildImage struct {
 	CpuSetMems     string
 	CgroupParent   string
 }
+
+type ListFilter struct {
+	Dangling bool
+	Labels   []string
+	Keys     []string
+}


### PR DESCRIPTION
Add support for the `filters` paramenter of the list images API.

I added support for the API documented [here](http://docs.docker.com/reference/api/docker_remote_api_v1.19/#list-images), later I realized that v1.15 supports only the `dangling` filter (as documented [here](http://docs.docker.com/reference/api/docker_remote_api_v1.15/#list-images)). What should I do?