### PR TITLE
WIP libnetwork - Add support for /networks and /services API endpoints

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -738,3 +738,242 @@ func (client *DockerClient) BuildImage(image *BuildImage) (io.ReadCloser, error)
 	uri := fmt.Sprintf("/%s/build?%s", APIVersion, v.Encode())
 	return client.doStreamRequest("POST", uri, image.Context, headers)
 }
+
+// Networks
+
+func (client *DockerClient) ListNetworks(name string, partialId string) ([]Network, error) {
+	uri := fmt.Sprintf("/%s/networks", APIVersion)
+
+	if name != "" {
+		uri += "&name=" + name
+	}
+
+	if partialId != "" {
+		uri += "&partial-id=" + partialId
+	}
+
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret := []Network{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (client *DockerClient) CreateNetwork(config *NetworkConfig) (string, error) {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	uri := fmt.Sprintf("/%s/networks", APIVersion)
+	data, err = client.doRequest("POST", uri, data, nil)
+	if err != nil {
+		return "", err
+	}
+	var ret string
+	err = json.Unmarshal(data, &ret)
+	return ret, nil
+}
+
+func (client *DockerClient) GetNetwork(id string) (*Network, error) {
+	uri := fmt.Sprintf("/%s/networks/%s", APIVersion, id)
+
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret := &Network{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (client *DockerClient) ListEndpoints(id string) ([]Endpoint, error) {
+	uri := fmt.Sprintf("/%s/networks/%s/endpoints", APIVersion, id)
+
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret := []Endpoint{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (client *DockerClient) CreateEndpoint(networkId string, config *EndpointConfig) (string, error) {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	uri := fmt.Sprintf("/%s/networks/%s/endpoints", APIVersion, networkId)
+	data, err = client.doRequest("POST", uri, data, nil)
+	if err != nil {
+		return "", err
+	}
+	var ret string
+	err = json.Unmarshal(data, &ret)
+	return ret, nil
+}
+
+func (client *DockerClient) GetEndpoint(networkId string, endpointId string) (*Endpoint, error) {
+	uri := fmt.Sprintf("/%s/networks/%s/endpoints/%s", APIVersion, networkId, endpointId)
+
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret := &Endpoint{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (client *DockerClient) JoinEndpoint(networkId string, endpointId string, config *JoinConfig) (string, error) {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	uri := fmt.Sprintf("/%s/networks/%s/endpoints/%s/containers", APIVersion, networkId, endpointId)
+	data, err = client.doRequest("POST", uri, data, nil)
+	if err != nil {
+		return "", err
+	}
+	var ret string
+	err = json.Unmarshal(data, &ret)
+	return ret, nil
+}
+
+func (client *DockerClient) DetachEndpoint(networkId string, endpointId string, containerId string) error {
+	uri := fmt.Sprintf("/%s/networks/%s/endpoints/%s/containers/%s", APIVersion, networkId, endpointId, containerId)
+	_, err := client.doRequest("DELETE", uri, nil, nil)
+	return err
+}
+
+func (client *DockerClient) DeleteEndpoint(networkId string, endpointId string) error {
+	uri := fmt.Sprintf("/%s/networks/%s/endpoints/%s", APIVersion, networkId, endpointId)
+	_, err := client.doRequest("DELETE", uri, nil, nil)
+	return err
+}
+
+func (client *DockerClient) DeleteNetwork(networkId string) error {
+	uri := fmt.Sprintf("/%s/networks/%s", APIVersion, networkId)
+	_, err := client.doRequest("DELETE", uri, nil, nil)
+	return err
+}
+
+// Services
+
+func (client *DockerClient) ListServices(name string, partialId string, network string) ([]Service, error) {
+	uri := fmt.Sprintf("/%s/services", APIVersion)
+
+	if name != "" {
+		uri += "&name=" + name
+	}
+
+	if partialId != "" {
+		uri += "&partial-id=" + partialId
+	}
+
+	if network != "" {
+		uri += "&network=" + network
+	}
+
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret := []Service{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (client *DockerClient) PublishService(config *ServiceConfig) (string, error) {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	uri := fmt.Sprintf("/%s/services", APIVersion)
+	data, err = client.doRequest("POST", uri, data, nil)
+	if err != nil {
+		return "", err
+	}
+	var ret string
+	err = json.Unmarshal(data, &ret)
+	return ret, nil
+}
+
+func (client *DockerClient) UnpublishService(serviceId string) error {
+	uri := fmt.Sprintf("/%s/services/%s", APIVersion, serviceId)
+	_, err := client.doRequest("DELETE", uri, nil, nil)
+	return err
+}
+
+func (client *DockerClient) GetService(id string) (*Service, error) {
+	uri := fmt.Sprintf("/%s/services/%s", APIVersion, id)
+
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret := &Service{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+func (client *DockerClient) AttachBackendToService(serviceId string, config *JoinConfig) (string, error) {
+	data, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	uri := fmt.Sprintf("/%s/services/%s/backend", APIVersion, serviceId)
+	data, err = client.doRequest("POST", uri, data, nil)
+	if err != nil {
+		return "", err
+	}
+	var ret string
+	err = json.Unmarshal(data, &ret)
+	return ret, nil
+}
+
+func (client *DockerClient) DetachBackendFromService(serviceId string, backendId string) error {
+	uri := fmt.Sprintf("/%s/services/%s/backend/%s", APIVersion, serviceId, backendId)
+	_, err := client.doRequest("DELETE", uri, nil, nil)
+	return err
+}
+
+func (client *DockerClient) ListBackends(serviceId string) ([]Backend, error) {
+	uri := fmt.Sprintf("/%s/services/%s/backend", APIVersion, serviceId)
+
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	ret := []Backend{}
+	err = json.Unmarshal(data, &ret)
+	if err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}

--- a/interface.go
+++ b/interface.go
@@ -45,4 +45,25 @@ type Client interface {
 	RenameContainer(oldName string, newName string) error
 	ImportImage(source string, repository string, tag string, tar io.Reader) (io.ReadCloser, error)
 	BuildImage(image *BuildImage) (io.ReadCloser, error)
+
+	// Networks
+	ListNetworks(name string, partialId string) ([]Network, error)
+	CreateNetwork(config *NetworkConfig) (string, error)
+	GetNetwork(networkId string) (*Network, error)
+	ListEndpoints(networkId string) ([]Endpoint, error)
+	CreateEndpoint(networkId string, config *EndpointConfig) (string, error)
+	GetEndpoint(networkId string, endpointId string) (*Endpoint, error)
+	JoinEndpoint(networkId string, endpointId string, config *JoinConfig) (string, error)
+	DetachEndpoint(networkId string, endpointId string, containerId string) error
+	DeleteEndpoint(networkId string, endpointId string) error
+	DeleteNetwork(networkId string) error
+
+	// Services
+	ListServices(name string, partialId string, network string) ([]Service, error)
+	PublishService(config *ServiceConfig) (string, error)
+	UnpublishService(serviceId string) error
+	GetService(serviceId string) (*Service, error)
+	AttachBackendToService(serviceId string, config *JoinConfig) (string, error)
+	DetachBackendFromService(serviceId string, backendId string) error
+	ListBackends(serviceId string) ([]Backend, error)
 }

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -170,3 +170,83 @@ func (client *MockClient) BuildImage(image *dockerclient.BuildImage) (io.ReadClo
 	args := client.Mock.Called(image)
 	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
+
+func (client *MockClient) ListNetworks(name string, partialId string) ([]dockerclient.Network, error) {
+	args := client.Mock.Called(name, partialId)
+	return args.Get(0).([]dockerclient.Network), args.Error(1)
+}
+
+func (client *MockClient) CreateNetwork(config *dockerclient.NetworkConfig) (string, error) {
+	args := client.Mock.Called(config)
+	return args.String(0), args.Error(1)
+}
+
+func (client *MockClient) GetNetwork(networkId string) (*dockerclient.Network, error) {
+	args := client.Mock.Called(networkId)
+	return args.Get(0).(*dockerclient.Network), args.Error(1)
+}
+
+func (client *MockClient) ListEndpoints(networkId string) ([]dockerclient.Endpoint, error) {
+	args := client.Mock.Called(networkId)
+	return args.Get(0).([]dockerclient.Endpoint), args.Error(1)
+}
+
+func (client *MockClient) CreateEndpoint(networkId string, config *dockerclient.EndpointConfig) (string, error) {
+	args := client.Mock.Called(networkId, config)
+	return args.String(0), args.Error(1)
+}
+
+func (client *MockClient) GetEndpoint(networkId string, endpointId string) (*dockerclient.Endpoint, error) {
+	args := client.Mock.Called(networkId, endpointId)
+	return args.Get(0).(*dockerclient.Endpoint), args.Error(1)
+}
+
+func (client *MockClient) JoinEndpoint(networkId string, endpointId string, config *dockerclient.JoinConfig) (string, error) {
+	args := client.Mock.Called(networkId, endpointId, config)
+	return args.String(0), args.Error(1)
+}
+
+func (client *MockClient) DetachEndpoint(networkId string, endpointId string, containerId string) error {
+	args := client.Mock.Called(networkId, endpointId, containerId)
+	return args.Error(0)
+}
+
+func (client *MockClient) DeleteEndpoint(networkId string, endpointId string) error {
+	args := client.Mock.Called(networkId, endpointId)
+	return args.Error(0)
+}
+
+func (client *MockClient) DeleteNetwork(networkId string) error {
+	args := client.Mock.Called(networkId)
+	return args.Error(0)
+}
+
+func (client *MockClient) ListServices(name string, partialId string, network string) ([]dockerclient.Service, error) {
+	args := client.Mock.Called(name, partialId, network)
+	return args.Get(0).([]dockerclient.Service), args.Error(1)
+}
+
+func (client *MockClient) PublishService(config *dockerclient.ServiceConfig) (string, error) {
+	args := client.Mock.Called(config)
+	return args.String(0), args.Error(1)
+}
+
+func (client *MockClient) UnpublishService(serviceId string) error {
+	args := client.Mock.Called(serviceId)
+	return args.Error(0)
+}
+
+func (client *MockClient) GetService(serviceId string) (*dockerclient.Service, error) {
+	args := client.Mock.Called(serviceId)
+	return args.Get(0).(*dockerclient.Service), args.Error(1)
+}
+
+func (client *MockClient) AttachBackendToService(serviceId string, config *dockerclient.JoinConfig) (string, error) {
+	args := client.Mock.Called(serviceId, config)
+	return args.String(0), args.Error(1)
+}
+
+func (client *MockClient) DetachBackendFromService(serviceId string, backendId string) error {
+	args := client.Mock.Called(serviceId, backendId)
+	return args.Error(0)
+}


### PR DESCRIPTION
Tested with docker experimental.

The API is going to change (with the `sandbox` entity: see docker/libnetwork#365), but I open the PR to keep track of the evolution on both sides.

*TODO* items:
- [ ] Add error scheme for all methods
- [ ] Move the networks and services endpoints in their own file (`networks.go`/`services.go`?)
- [ ] Include new `sandbox` entity
- [ ] Refactor and split tests

Signed-off-by: Alexandre Beslic <abronan@docker.com>