### PR TITLE
Provide the /containers/<id>/resize endpoint

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -305,23 +305,6 @@ func (client *DockerClient) ExecStart(id string, config *ExecConfig) error {
 	return nil
 }
 
-func (client *DockerClient) ExecResize(id string, width, height int) error {
-	v := url.Values{}
-
-	w := strconv.Itoa(width)
-	h := strconv.Itoa(height)
-
-	v.Set("w", w)
-	v.Set("h", h)
-
-	uri := fmt.Sprintf("/%s/exec/%s/resize?%s", APIVersion, id, v.Encode())
-	if _, err := client.doRequest("POST", client.URL.String()+uri, nil, nil); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (client *DockerClient) StartContainer(id string, config *HostConfig) error {
 	data, err := json.Marshal(config)
 	if err != nil {
@@ -359,6 +342,24 @@ func (client *DockerClient) KillContainer(id, signal string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (client *DockerClient) ResizeContainer(id string, isExec bool, width, height int) error {
+	v := url.Values{}
+	v.Set("w", strconv.Itoa(width))
+	v.Set("h", strconv.Itoa(height))
+
+	var uri string
+	if isExec {
+		uri = fmt.Sprintf("/%s/exec/%s/resize?%s", APIVersion, id, v.Encode())
+	} else {
+		uri = fmt.Sprintf("/%s/containers/%s/resize?%s", APIVersion, id, v.Encode())
+	}
+	if _, err := client.doRequest("POST", uri, nil, nil); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/interface.go
+++ b/interface.go
@@ -18,11 +18,11 @@ type Client interface {
 	ContainerChanges(id string) ([]*ContainerChanges, error)
 	ExecCreate(config *ExecConfig) (string, error)
 	ExecStart(id string, config *ExecConfig) error
-	ExecResize(id string, width, height int) error
 	StartContainer(id string, config *HostConfig) error
 	StopContainer(id string, timeout int) error
 	RestartContainer(id string, timeout int) error
 	KillContainer(id, signal string) error
+	ResizeContainer(id string, isExec bool, width, height int) error
 	Wait(id string) <-chan WaitResult
 	// MonitorEvents takes options and an optional stop channel, and returns
 	// an EventOrError channel. If an error is ever sent, then no more


### PR DESCRIPTION
This can be merged with the function that implements the /exec/<id>/resize
endpoint, since they are almost identical. Note that the Docker CLI does this
too.

Signed-off-by: Miquel Sabaté <msabate@suse.com>