### PR TITLE
disable keep alive for swarm compatibility

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -10,7 +10,8 @@ import (
 
 func newHTTPClient(u *url.URL, tlsConfig *tls.Config, timeout time.Duration) *http.Client {
 	httpTransport := &http.Transport{
-		TLSClientConfig: tlsConfig,
+		TLSClientConfig:   tlsConfig,
+		DisableKeepAlives: true,
 	}
 
 	switch u.Scheme {


### PR DESCRIPTION
Using this client against Docker Swarm can produce unexpected behavior when Swarm hijacks the request and routes it to a specific node. Subsequent requests that reuse the connection go to the proxied node, not Swarm.

Given a Swarm server S with nodes A and B:
Send ExecCreate and ExecStart to S and execute a command in a container on Node A.
Swarm hijacks the ExecStart request connection and sends it to Node A
Subsequent requests bypass S and go directly to A until the http.Transport creates a new connection.

Disabling Keep Alive ensures that all requests go to S while still allowing hijacked requests for log streaming etc.
