### PR TITLE
Add make dockerfile travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+Godeps/_workspace/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+
+language: go
+
+go_import_path: github.com/samalba/dockerclient
+
+go:
+    - 1.4
+    - 1.5
+
+script: godep go test -v ./...

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,8 @@
+
+FROM    golang:1.5
+RUN     mkdir -p /tmp/godep && \
+        GOPATH=/tmp/godep go get github.com/tools/godep && \
+        mv /tmp/godep/bin/godep /usr/local/bin/godep && \
+        rm -rf /tmp/godep
+
+WORKDIR /go/src/github.com/samalba/dockerclient

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,59 @@
+{
+	"ImportPath": "github.com/samalba/dockerclient",
+	"GoVersion": "go1.5",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.8.7",
+			"Rev": "418b41d23a1bf978c06faea5313ba194650ac088"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/ioutils",
+			"Comment": "v1.4.1-6487-g724b410",
+			"Rev": "724b410c555a278d428929d125005d624d4a94a5"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/jsonlog",
+			"Comment": "v1.4.1-6487-g724b410",
+			"Rev": "724b410c555a278d428929d125005d624d4a94a5"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/stdcopy",
+			"Comment": "v1.4.1-6487-g724b410",
+			"Rev": "724b410c555a278d428929d125005d624d4a94a5"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/timeutils",
+			"Comment": "v1.4.1-6487-g724b410",
+			"Rev": "724b410c555a278d428929d125005d624d4a94a5"
+		},
+		{
+			"ImportPath": "github.com/docker/docker/pkg/units",
+			"Comment": "v1.4.1-6487-g724b410",
+			"Rev": "724b410c555a278d428929d125005d624d4a94a5"
+		},
+		{
+			"ImportPath": "github.com/gorilla/context",
+			"Rev": "1c83b3eabd45b6d76072b66b746c20815fb2872d"
+		},
+		{
+			"ImportPath": "github.com/gorilla/mux",
+			"Rev": "49c024275504f0341e5a9971eb7ba7fa3dc7af40"
+		},
+		{
+			"ImportPath": "github.com/stretchr/objx",
+			"Rev": "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
+		},
+		{
+			"ImportPath": "github.com/stretchr/testify/assert",
+			"Rev": "dab07ac62d4905d3e48d17dc549c684ac3b7c15a"
+		},
+		{
+			"ImportPath": "github.com/stretchr/testify/mock",
+			"Rev": "dab07ac62d4905d3e48d17dc549c684ac3b7c15a"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build shell test-unit
+
+
+BUILD_ID ?= $(shell git rev-parse --short HEAD 2>/dev/null)
+DOCKER_IMAGE := dockerclient-dev:$(BUILD_ID)
+
+VOLUMES := \
+	-v $(CURDIR):/go/src/github.com/samalba/dockerclient \
+	-v $(CURDIR)/dist/bin:/go/bin \
+	-v $(CURDIR)/dist/pkg:/go/pkg
+
+all: binary
+
+build:
+	docker build -t $(DOCKER_IMAGE) -f Dockerfile.build .
+
+dist:
+	mkdir dist/
+
+shell: dist build
+	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) bash
+
+test-unit: build
+	docker run --rm -ti $(VOLUMES) $(DOCKER_IMAGE) godep go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Docker client library in Go
 ===========================
 [![GoDoc](http://godoc.org/github.com/samalba/dockerclient?status.png)](http://godoc.org/github.com/samalba/dockerclient)
+[![Build Status](https://travis-ci.org/samalba/dockerclient.svg?branch=master)](https://travis-ci.org/samalba/dockerclient)
 
 Well maintained docker client library.
 


### PR DESCRIPTION
Adds:
* travis.ci integration and badge
* makefile and Dockerfile for building/testing without having to install a specific version of go on the host

Travis shows there is one flaky test (#164)