### PR TITLE
Report pull progress to an optionally provided io.Writer

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -528,7 +528,7 @@ func (client *DockerClient) Version() (*Version, error) {
 	return version, nil
 }
 
-func (client *DockerClient) PullImage(name string, auth *AuthConfig, cliOut io.Writer) (err error) {
+func (client *DockerClient) PullImage(name string, auth *AuthConfig, out ...io.Writer) (err error) {
 	v := url.Values{}
 	v.Set("fromImage", name)
 	uri := fmt.Sprintf("/%s/images/create?%s", APIVersion, v.Encode())
@@ -559,6 +559,10 @@ func (client *DockerClient) PullImage(name string, auth *AuthConfig, cliOut io.W
 	}
 
 	errorReader := io.Reader(resp.Body)
+	var cliOut io.Writer
+	if len(out) > 0 {
+		cliOut = out[0]
+	}
 	if cliOut != nil {
 		pipeReader, pipeWriter := io.Pipe()
 		streamErrChan := make(chan error)

--- a/dockerclient_test.go
+++ b/dockerclient_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -29,6 +30,16 @@ func testDockerClient(t *testing.T) *DockerClient {
 		t.Fatal("Cannot init the docker client")
 	}
 	return client
+}
+
+func ExampleDockerClient_PullImage() {
+	docker, err := NewDockerClient("unix:///var/run/docker.sock", nil)
+	if err != nil {
+		panic(err)
+	}
+	if err := docker.PullImage("busybox", nil, os.Stdout); err != nil {
+		panic(err)
+	}
 }
 
 func TestInfo(t *testing.T) {
@@ -70,17 +81,17 @@ func TestWait(t *testing.T) {
 
 func TestPullImage(t *testing.T) {
 	client := testDockerClient(t)
-	err := client.PullImage("busybox", nil)
+	err := client.PullImage("busybox", nil, nil)
 	if err != nil {
-		t.Fatal("unable to pull busybox")
+		t.Fatal("unable to pull busybox: %v", err)
 	}
 
-	err = client.PullImage("haproxy", nil)
+	err = client.PullImage("haproxy", nil, nil)
 	if err != nil {
-		t.Fatal("unable to pull haproxy")
+		t.Fatal("unable to pull haproxy: %v", err)
 	}
 
-	err = client.PullImage("wrongimg", nil)
+	err = client.PullImage("wrongimg", nil, nil)
 	if err == nil {
 		t.Fatal("should return error when it fails to pull wrongimg")
 	}

--- a/dockerclient_test.go
+++ b/dockerclient_test.go
@@ -81,17 +81,17 @@ func TestWait(t *testing.T) {
 
 func TestPullImage(t *testing.T) {
 	client := testDockerClient(t)
-	err := client.PullImage("busybox", nil, nil)
+	err := client.PullImage("busybox", nil) // old clients do not break on the API change
 	if err != nil {
 		t.Fatal("unable to pull busybox: %v", err)
 	}
 
-	err = client.PullImage("haproxy", nil, nil)
+	err = client.PullImage("haproxy", nil, os.Stderr) // io.Writer is optional
 	if err != nil {
 		t.Fatal("unable to pull haproxy: %v", err)
 	}
 
-	err = client.PullImage("wrongimg", nil, nil)
+	err = client.PullImage("wrongimg", nil)
 	if err == nil {
 		t.Fatal("should return error when it fails to pull wrongimg")
 	}

--- a/interface.go
+++ b/interface.go
@@ -35,7 +35,7 @@ type Client interface {
 	StopAllMonitorStats()
 	TagImage(nameOrID string, repo string, tag string, force bool) error
 	Version() (*Version, error)
-	PullImage(name string, auth *AuthConfig, cliOut io.Writer) error
+	PullImage(name string, auth *AuthConfig, out ...io.Writer) error
 	LoadImage(reader io.Reader) error
 	RemoveContainer(id string, force, volumes bool) error
 	ListImages(all bool) ([]*Image, error)

--- a/interface.go
+++ b/interface.go
@@ -35,7 +35,7 @@ type Client interface {
 	StopAllMonitorStats()
 	TagImage(nameOrID string, repo string, tag string, force bool) error
 	Version() (*Version, error)
-	PullImage(name string, auth *AuthConfig) error
+	PullImage(name string, auth *AuthConfig, cliOut io.Writer) error
 	LoadImage(reader io.Reader) error
 	RemoveContainer(id string, force, volumes bool) error
 	ListImages(all bool) ([]*Image, error)

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -106,8 +106,8 @@ func (client *MockClient) Version() (*dockerclient.Version, error) {
 	return args.Get(0).(*dockerclient.Version), args.Error(1)
 }
 
-func (client *MockClient) PullImage(name string, auth *dockerclient.AuthConfig, cliOut io.Writer) error {
-	args := client.Mock.Called(name, auth, cliOut)
+func (client *MockClient) PullImage(name string, auth *dockerclient.AuthConfig, out ...io.Writer) error {
+	args := client.Mock.Called(name, auth, out...)
 	return args.Error(0)
 }
 

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -106,8 +106,8 @@ func (client *MockClient) Version() (*dockerclient.Version, error) {
 	return args.Get(0).(*dockerclient.Version), args.Error(1)
 }
 
-func (client *MockClient) PullImage(name string, auth *dockerclient.AuthConfig) error {
-	args := client.Mock.Called(name, auth)
+func (client *MockClient) PullImage(name string, auth *dockerclient.AuthConfig, cliOut io.Writer) error {
+	args := client.Mock.Called(name, auth, cliOut)
 	return args.Error(0)
 }
 

--- a/nopclient/nop.go
+++ b/nopclient/nop.go
@@ -94,7 +94,7 @@ func (client *NopClient) Version() (*dockerclient.Version, error) {
 	return nil, ErrNoEngine
 }
 
-func (client *NopClient) PullImage(name string, auth *dockerclient.AuthConfig) error {
+func (client *NopClient) PullImage(name string, auth *dockerclient.AuthConfig, out ...io.Writer) error {
 	return ErrNoEngine
 }
 


### PR DESCRIPTION
Uses code from #124, only makes the API friendly to old clients, making the out stream optional. 
