### PR TITLE
Fix a file descriptor leak when handling 404 

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -102,6 +102,7 @@ func (client *DockerClient) doStreamRequest(method string, path string, in io.Re
 		return nil, err
 	}
 	if resp.StatusCode == 404 {
+		defer resp.Body.Close()
 		return nil, ErrNotFound
 	}
 	if resp.StatusCode >= 400 {


### PR DESCRIPTION
Any non-nil HTTP client response needs to have
its .Body stream closed, otherwise the client socket
associated file descriptor is not closed also and
long-running processes end up in a deadly "too many files open"
state especially when they get a lot of "Image/container not found"
responses - pretty common. Think Docker Swarm - which is actually
the case where I was bit by this and which I used to verify
that the fix is working.

Signed-off-by: Mariusz Borsa mborsa@polyverse.io