### PR TITLE
Add support for buildargs in POST /build.

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -760,6 +760,13 @@ func (client *DockerClient) BuildImage(image *BuildImage) (io.ReadCloser, error)
 	v.Set("cpusetcpus", image.CpuSetCpus)
 	v.Set("cpusetmems", image.CpuSetMems)
 	v.Set("cgroupparent", image.CgroupParent)
+	if image.BuildArgs != nil {
+		buildArgsJSON, err := json.Marshal(image.BuildArgs)
+		if err != nil {
+			return nil, err
+		}
+		v.Set("buildargs", string(buildArgsJSON))
+	}
 
 	headers := make(map[string]string)
 	if image.Config != nil {

--- a/types.go
+++ b/types.go
@@ -443,6 +443,7 @@ type BuildImage struct {
 	CpuSetCpus     string
 	CpuSetMems     string
 	CgroupParent   string
+	BuildArgs      map[string]string
 }
 
 type Volume struct {


### PR DESCRIPTION
I want this to try to implement affinity support for building images into swarm.
https://github.com/docker/swarm/issues/1282

I didn't find any test for BuildImage. I'm willing to try to write one, with a bit of guidance.

My code is very similar to the one in Docker's api/client package, so maybe I can get away with that?
https://github.com/docker/docker/blob/ef4b053b9064888eadf25e48f7f1d4d5896da8fb/api/client/build.go#L271

Thank you for taking a look at this!