### PR TITLE
Add token pass-thru for AuthConfig

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -8,9 +8,10 @@ import (
 
 // AuthConfig hold parameters for authenticating with the docker registry
 type AuthConfig struct {
-	Username string `json:"username,omitempty"`
-	Password string `json:"password,omitempty"`
-	Email    string `json:"email,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Email         string `json:"email,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
 // encode the auth configuration struct into base64 for the X-Registry-Auth header

--- a/dockerclient_test.go
+++ b/dockerclient_test.go
@@ -40,7 +40,7 @@ func ExampleDockerClient_AttachContainer() {
 	cID, err := docker.CreateContainer(&ContainerConfig{
 		Cmd:   []string{"echo", "hi"},
 		Image: "busybox",
-	}, "")
+	}, "", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/stats/stats.go
+++ b/examples/stats/stats.go
@@ -27,7 +27,7 @@ func main() {
 	}
 
 	containerConfig := &dockerclient.ContainerConfig{Image: "busybox", Cmd: []string{"sh"}}
-	containerId, err := docker.CreateContainer(containerConfig, "")
+	containerId, err := docker.CreateContainer(containerConfig, "", nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/interface.go
+++ b/interface.go
@@ -13,7 +13,7 @@ type Client interface {
 	ListContainers(all, size bool, filters string) ([]Container, error)
 	InspectContainer(id string) (*ContainerInfo, error)
 	InspectImage(id string) (*ImageInfo, error)
-	CreateContainer(config *ContainerConfig, name string) (string, error)
+	CreateContainer(config *ContainerConfig, name string, authConfig *AuthConfig) (string, error)
 	ContainerLogs(id string, options *LogOptions) (io.ReadCloser, error)
 	ContainerChanges(id string) ([]*ContainerChanges, error)
 	ExecCreate(config *ExecConfig) (string, error)

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -35,7 +35,7 @@ func (client *MockClient) InspectImage(id string) (*dockerclient.ImageInfo, erro
 	return args.Get(0).(*dockerclient.ImageInfo), args.Error(1)
 }
 
-func (client *MockClient) CreateContainer(config *dockerclient.ContainerConfig, name string) (string, error) {
+func (client *MockClient) CreateContainer(config *dockerclient.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (string, error) {
 	args := client.Mock.Called(config, name)
 	return args.String(0), args.Error(1)
 }

--- a/nopclient/nop.go
+++ b/nopclient/nop.go
@@ -34,7 +34,7 @@ func (client *NopClient) InspectImage(id string) (*dockerclient.ImageInfo, error
 	return nil, ErrNoEngine
 }
 
-func (client *NopClient) CreateContainer(config *dockerclient.ContainerConfig, name string) (string, error) {
+func (client *NopClient) CreateContainer(config *dockerclient.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (string, error) {
 	return "", ErrNoEngine
 }
 


### PR DESCRIPTION
This extends the AuthConfig to allow token pass-thru and augments the
CreateContainer API to set the X-Registry-Auth header if an AuthConfig
is passed in.  This will allow Swarm to pull private images on specific
nodes based on container creation.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>