### PR TITLE
add options field to NetworkCreate

### DIFF
--- a/types.go
+++ b/types.go
@@ -518,6 +518,7 @@ type NetworkCreate struct {
 	CheckDuplicate bool
 	Driver         string
 	IPAM           IPAM
+	Options        map[string]string
 }
 
 // NetworkCreateResponse is the response message sent by the server for network create call


### PR DESCRIPTION
Adds `Options` to `NetworkCreate`.

Reference: https://github.com/docker/docker/blob/master/api/types/types.go#L375