### PR TITLE
Fix exec resize - it was prepending URL to the path which broke the call

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -328,7 +328,7 @@ func (client *DockerClient) ExecResize(id string, width, height int) error {
 	v.Set("h", h)
 
 	uri := fmt.Sprintf("/%s/exec/%s/resize?%s", APIVersion, id, v.Encode())
-	if _, err := client.doRequest("POST", client.URL.String()+uri, nil, nil); err != nil {
+	if _, err := client.doRequest("POST", uri, nil, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
No need to prepend `client.URL.String()` to the `doRequest` call