### PR TITLE
Add missing AuthConfig call to mock

### DIFF
--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -36,7 +36,7 @@ func (client *MockClient) InspectImage(id string) (*dockerclient.ImageInfo, erro
 }
 
 func (client *MockClient) CreateContainer(config *dockerclient.ContainerConfig, name string, authConfig *dockerclient.AuthConfig) (string, error) {
-	args := client.Mock.Called(config, name)
+	args := client.Mock.Called(config, name, authConfig)
 	return args.String(0), args.Error(1)
 }
 


### PR DESCRIPTION
This change keeps the mock client in sync with the recent
change to the AuthConfig from PR #184

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>