### PR TITLE
Replace pkg/units with the docker/go-units package

### DIFF
--- a/types.go
+++ b/types.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/docker/docker/pkg/units"
+	"github.com/docker/go-units"
 )
 
 type ContainerConfig struct {


### PR DESCRIPTION
As mentioned [here](https://github.com/opencontainers/runc/pull/435), the `units` library in docker/pkg will be replaced by the `go-units`.

**Note** This update isn't supposed to change any functionality of the package.