### PR TITLE
Add NetworkSettings field to /containers/json response

### DIFF
--- a/types.go
+++ b/types.go
@@ -252,17 +252,31 @@ type Port struct {
 	Type        string
 }
 
+type EndpointSettings struct {
+	EndpointID          string
+	Gateway             string
+	IPAddress           string
+	IPPrefixLen         int
+	IPv6Gateway         string
+	GlobalIPv6Address   string
+	GlobalIPv6PrefixLen int
+	MacAddress          string
+}
+
 type Container struct {
-	Id         string
-	Names      []string
-	Image      string
-	Command    string
-	Created    int64
-	Status     string
-	Ports      []Port
-	SizeRw     int64
-	SizeRootFs int64
-	Labels     map[string]string
+	Id              string
+	Names           []string
+	Image           string
+	Command         string
+	Created         int64
+	Status          string
+	Ports           []Port
+	SizeRw          int64
+	SizeRootFs      int64
+	Labels          map[string]string
+	NetworkSettings struct {
+		Networks map[string]EndpointSettings
+	}
 }
 
 type Event struct {


### PR DESCRIPTION
@abronan Hello, I am adding the `NetworkSettings>Networks` property I introduced in Docker Remote API v1.22 and I will integrate this to Swarm afterwards by updating vended package.

More info: https://github.com/docker/docker/pull/18559 

My end goal is to find out which network each container is in along with its IP address in `/containers/json` response (otherwise I need to query each container's info individually) so that with [wagl](https://github.com/ahmetalpbalkan/wagl) I can provide seamless name resolution for containers in the same overlay network.

Copied `EndpointSettings` from [here](https://github.com/docker/docker/blob/10bbe0ee7ccb3f8e6c37f84b89a887e882f83944/api/types/network/network.go#L24).