### PR TITLE
Accelerate dead peer detection with user timeout option

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -16,7 +16,15 @@ func newHTTPClient(u *url.URL, tlsConfig *tls.Config, timeout time.Duration) *ht
 	switch u.Scheme {
 	default:
 		httpTransport.Dial = func(proto, addr string) (net.Conn, error) {
-			return net.DialTimeout(proto, addr, timeout)
+			conn, err := net.DialTimeout(proto, addr, timeout)
+			if tcpConn, ok := conn.(*net.TCPConn); ok {
+				// Set TCP user timeout. Sender breaks TCP connection
+				// if packets are not acknowledged after 20 seconds. This is a
+				// relatively new TCP option to improve dead peer detection.
+				// Do not fail newHTTPClient if OS doesn's support it.
+				SetTCPUserTimeout(tcpConn, 20*time.Second)
+			}
+			return conn, err
 		}
 	case "unix":
 		socketPath := u.Path

--- a/utils.go
+++ b/utils.go
@@ -22,7 +22,13 @@ func newHTTPClient(u *url.URL, tlsConfig *tls.Config, timeout time.Duration) *ht
 				// if packets are not acknowledged after 20 seconds. This is a
 				// relatively new TCP option to improve dead peer detection.
 				// Do not fail newHTTPClient if OS doesn's support it.
-				SetTCPUserTimeout(tcpConn, 20*time.Second)
+
+				// user timeout shouldn't be too aggressive
+				userTimeout := timeout
+				if userTimeout < 20*time.Second {
+					userTimeout = 20 * time.Second
+				}
+				SetTCPUserTimeout(tcpConn, userTimeout)
 			}
 			return conn, err
 		}

--- a/utils_unix.go
+++ b/utils_unix.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+package dockerclient
+
+// #include <netinet/tcp.h>
+import "C"
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+// SetTCPUserTimeout sets TCP_USER_TIMEOUT according to RFC5842
+func SetTCPUserTimeout(conn *net.TCPConn, uto time.Duration) error {
+	f, err := conn.File()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	msecs := int(uto.Nanoseconds() / 1e6)
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(f.Fd()), syscall.SOL_TCP, C.TCP_USER_TIMEOUT, msecs))
+}

--- a/utils_windows.go
+++ b/utils_windows.go
@@ -1,0 +1,28 @@
+// +build windows
+
+package dockerclient
+
+// #include <Ws2tcpip.h>
+import "C"
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+// SetTCPUserTimeout sets TCP_MAXRT in Windows
+func SetTCPUserTimeout(conn *net.TCPConn, uto time.Duration) error {
+	f, err := conn.File()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// TCP_MAXRT in Windows is set as seconds
+	secs := int(uto.Nanoseconds() / 1e9)
+
+	// from MSDN, TCP_MAXRT is supported since Windows Vista
+	return os.NewSyscallError("setsockopt", syscall.SetsockoptInt(int(f.Fd()), syscall.SOL_TCP, C.TCP_MAXRT, secs))
+}


### PR DESCRIPTION
Dockerclient are used by other tools like swarm. Swarm manager normally maintains 2-6 established TCP connections with an engine thru HTTP keepalive. When an engine goes offline abruptly, like engine crash, host pause, network failure, these connections remain in `Established` state. By default swarm manager relies on system dead connection detection mechanism to fail requests. In typical Linux system it's around 13-20 minutes, depending on tcp_retries1, tcp_retries2 and retransmit timeout value. From user perspective, docker CLI hangs.   

RFC5482 defines TCP_USER_TIMEOUT so a sender can break the connection faster. While Golang doesn't support this socket option. Linux and Windows have different options to support user timeout. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>