### PR TITLE
remove timeutils and use jsonlog for engine mock test

### DIFF
--- a/engine_mock_test.go
+++ b/engine_mock_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/docker/docker/pkg/timeutils"
 	"github.com/gorilla/mux"
 )
 
@@ -109,7 +108,7 @@ func handleContainerLogs(w http.ResponseWriter, r *http.Request) {
 		line := fmt.Sprintf("line %d", i)
 		if getBoolValue(r.Form.Get("timestamps")) {
 			l := &jsonlog.JSONLog{Log: line, Created: time.Now().UTC()}
-			line = fmt.Sprintf("%s %s", l.Created.Format(timeutils.RFC3339NanoFixed), line)
+			line = fmt.Sprintf("%s %s", l.Created.Format(jsonlog.RFC3339NanoFixed), line)
 		}
 		if i%2 == 0 && stderr {
 			fmt.Fprintln(errStream, line)


### PR DESCRIPTION
This fixes the mock test to use `jsonlog` instead of the recently moved `timeutils`.