### PR TITLE
Add swarm Node field into ContainerInfo

### DIFF
--- a/types.go
+++ b/types.go
@@ -238,6 +238,12 @@ type ContainerInfo struct {
 	ResolvConfPath string
 	Volumes        map[string]string
 	HostConfig     *HostConfig
+	Node           struct {
+		Id   string
+		Ip   string
+		Addr string
+		Name string
+	}
 }
 
 type ContainerChanges struct {


### PR DESCRIPTION
Swarm introduces the new field Node in the /containers/{name}/json endpoint
