### PR TITLE
Syntax fix to work with Go 1.3

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -280,7 +280,7 @@ func (client *DockerClient) readJSONStream(stream io.ReadCloser, decode func(*js
 			select {
 			case <-stopChan:
 				stream.Close()
-				for range decodeChan {
+				for _ = range decodeChan {
 				}
 				return
 			case decodeResult := <-decodeChan:


### PR DESCRIPTION
Tweak syntax so that dockerclient can be compiled with Go 1.3 (current master uses syntax that is only available in Go 1.4+)

