### PR TITLE
Do not close nil channel. With the change in swarm, engine in pending…

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -513,6 +513,9 @@ func (client *DockerClient) StartMonitorEvents(cb Callback, ec chan error, args 
 }
 
 func (client *DockerClient) StopAllMonitorEvents() {
+	if client.eventStopChan == nil {
+		return
+	}
 	close(client.eventStopChan)
 }
 


### PR DESCRIPTION
Do not close nil channel. With the change in swarm, engine in pending state may have a dockerclient where monitor channel is not created.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>