### PR TITLE
an option to disconnect an endpoint from a network forcefully

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -920,8 +920,8 @@ func (client *DockerClient) ConnectNetwork(id, container string) error {
 	return err
 }
 
-func (client *DockerClient) DisconnectNetwork(id, container string) error {
-	data, err := json.Marshal(NetworkDisconnect{Container: container})
+func (client *DockerClient) DisconnectNetwork(id, container string, force bool) error {
+	data, err := json.Marshal(NetworkDisconnect{Container: container, Force: force})
 	if err != nil {
 		return err
 	}

--- a/interface.go
+++ b/interface.go
@@ -54,6 +54,6 @@ type Client interface {
 	InspectNetwork(id string) (*NetworkResource, error)
 	CreateNetwork(config *NetworkCreate) (*NetworkCreateResponse, error)
 	ConnectNetwork(id, container string) error
-	DisconnectNetwork(id, container string) error
+	DisconnectNetwork(id, container string, force bool) error
 	RemoveNetwork(id string) error
 }

--- a/mockclient/mock.go
+++ b/mockclient/mock.go
@@ -216,8 +216,8 @@ func (client *MockClient) ConnectNetwork(id, container string) error {
 	return args.Error(0)
 }
 
-func (client *MockClient) DisconnectNetwork(id, container string) error {
-	args := client.Mock.Called(id, container)
+func (client *MockClient) DisconnectNetwork(id, container string, force bool) error {
+	args := client.Mock.Called(id, container, force)
 	return args.Error(0)
 }
 

--- a/nopclient/nop.go
+++ b/nopclient/nop.go
@@ -182,7 +182,7 @@ func (client *NopClient) ConnectNetwork(id, container string) error {
 	return ErrNoEngine
 }
 
-func (client *NopClient) DisconnectNetwork(id, container string) error {
+func (client *NopClient) DisconnectNetwork(id, container string, force bool) error {
 	return ErrNoEngine
 }
 

--- a/types.go
+++ b/types.go
@@ -551,4 +551,5 @@ type NetworkConnect struct {
 // NetworkDisconnect represents the data to be used to disconnect a container from the network
 type NetworkDisconnect struct {
 	Container string
+	Force     bool
 }


### PR DESCRIPTION
since we are not yes using engine-api we need to duplicate this change here: https://github.com/docker/engine-api/pull/29