### PR TITLE
Add a Ping() function to call the _ping endpoint

### DIFF
--- a/dockerclient.go
+++ b/dockerclient.go
@@ -156,6 +156,16 @@ func (client *DockerClient) Info() (*Info, error) {
 	return ret, nil
 }
 
+func (client *DockerClient) Ping() (string, error) {
+	uri := fmt.Sprintf("/%s/_ping", APIVersion)
+	data, err := client.doRequest("GET", uri, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
 func (client *DockerClient) ListContainers(all bool, size bool, filters string) ([]Container, error) {
 	argAll := 0
 	if all == true {

--- a/dockerclient_test.go
+++ b/dockerclient_test.go
@@ -76,6 +76,15 @@ func TestInfo(t *testing.T) {
 	assertEqual(t, info.Containers, int64(2), "")
 }
 
+func TestPing(t *testing.T) {
+	client := testDockerClient(t)
+	pong, err := client.Ping()
+	if err != nil {
+		t.Fatal("Cannot ping server")
+	}
+	assertEqual(t, pong, "OK", "")
+}
+
 func TestKillContainer(t *testing.T) {
 	client := testDockerClient(t)
 	if err := client.KillContainer("23132acf2ac", "5"); err != nil {


### PR DESCRIPTION
I propose this PR in order to add a function Ping() on the dockerclient to call the _ping endpoint of the docker daemon remote api.

I use this function to check if a docker host is still alive, I know that I could use Info() or Version() but I think this one is more lightweight if you don't care about any of the Info() or Version() results. 