### PR TITLE
add labels to images, networks and volumes

### DIFF
--- a/types.go
+++ b/types.go
@@ -536,12 +536,14 @@ type BuildImage struct {
 	CpuSetMems     string
 	CgroupParent   string
 	BuildArgs      map[string]string
+	Labels         map[string]string // Labels hold metadata about the image
 }
 
 type Volume struct {
-	Name       string // Name is the name of the volume
-	Driver     string // Driver is the Driver name used to create the volume
-	Mountpoint string // Mountpoint is the location on disk of the volume
+	Name       string            // Name is the name of the volume
+	Driver     string            // Driver is the Driver name used to create the volume
+	Mountpoint string            // Mountpoint is the location on disk of the volume
+	Labels     map[string]string // Labels hold metadata about the volume
 }
 
 type VolumesListResponse struct {
@@ -552,6 +554,7 @@ type VolumeCreateRequest struct {
 	Name       string            // Name is the requested name of the volume
 	Driver     string            // Driver is the name of the driver that should be used to create the volume
 	DriverOpts map[string]string // DriverOpts holds the driver specific options to use for when creating the volume.
+	Labels     map[string]string // Labels hold metadata about the volume
 }
 
 // IPAM represents IP Address Management
@@ -585,6 +588,7 @@ type NetworkResource struct {
 	//Internal   bool
 	Containers map[string]EndpointResource
 	Options    map[string]string
+	Labels     map[string]string // Labels hold metadata about the network
 }
 
 // EndpointResource contains network resources allocated and used for a container in a network
@@ -604,6 +608,7 @@ type NetworkCreate struct {
 	IPAM           IPAM
 	Internal       bool
 	Options        map[string]string
+	Labels         map[string]string // Labels hold metadata about the network
 }
 
 // NetworkCreateResponse is the response message sent by the server for network create call


### PR DESCRIPTION
This adds label support for images (build), networks and volumes.

Refs: https://github.com/docker/engine-api/pull/156