### PR TITLE
Omit 0 ShmSize from HostConfig JSON to resolve compatibility issue with Docker 1.9.1

### DIFF
--- a/types.go
+++ b/types.go
@@ -91,7 +91,7 @@ type HostConfig struct {
 	VolumeDriver         string
 	OomScoreAdj          int
 	Tmpfs                map[string]string
-	ShmSize              int64
+	ShmSize              int64 `json:"omitempty"`
 	BlkioWeightDevice    []WeightDevice
 	BlkioDeviceReadBps   []ThrottleDevice
 	BlkioDeviceWriteBps  []ThrottleDevice


### PR DESCRIPTION
In Docker 1.9.1, an SHMSize of 0 is invalid and results in an error rather than being replaced by the default value.
In applications such as [Drone](https://github/drone/drone) that use dockerclient while not exposing all config values, this issue renders the application unusable with Docker 1.9.1.

In Docker >= 1.10 this is not an issue as the behaviour for an SHMSize of 0 is the same as nill (See [acfd5eb](https://github.com/docker/docker/commit/acfd5eb947bff31239701e754814787e92e1d17f#diff-10)). However, there are reasons for some people to be pinned to Docker 1.9.1 for the time being, eg when using Openshift.

I have not added tags to other fields as I wanted to limit the scope of this change to fixing this specific issue.

@crosbymichael, @vieux, @ehazlett

Thanks