### PR TITLE
Please add proxy support

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -13,6 +13,7 @@ type tcpFunc func(*net.TCPConn, time.Duration) error
 func newHTTPClient(u *url.URL, tlsConfig *tls.Config, timeout time.Duration, setUserTimeout tcpFunc) *http.Client {
 	httpTransport := &http.Transport{
 		TLSClientConfig: tlsConfig,
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	switch u.Scheme {


### PR DESCRIPTION
While using _docker-toolbox_ we figured out that _dockerclient_ doesn't respect the proxy settings of the system environment.  Because of that we're not able to manage amazon ec2 instances properly out of our corporate network. 

We're still dependent on Win8.1 and docker-toolbox, hence I kindly ask you to merge this PR into your codebase.

Thank you!

CV