### PR TITLE
Update the dependency for jsonlog

### DIFF
--- a/engine_mock_test.go
+++ b/engine_mock_test.go
@@ -3,6 +3,7 @@ package dockerclient
 import (
 	"encoding/json"
 	"fmt"
+
 	"io"
 	"log"
 	"net/http"
@@ -10,8 +11,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/docker/docker/daemon/logger/jsonfilelog/jsonlog"
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/jsonlog"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/gorilla/mux"
 )
@@ -109,7 +111,7 @@ func handleContainerLogs(w http.ResponseWriter, r *http.Request) {
 		line := fmt.Sprintf("line %d", i)
 		if getBoolValue(r.Form.Get("timestamps")) {
 			l := &jsonlog.JSONLog{Log: line, Created: time.Now().UTC()}
-			line = fmt.Sprintf("%s %s", l.Created.Format(jsonlog.RFC3339NanoFixed), line)
+			line = fmt.Sprintf("%s %s", l.Created.Format(jsonmessage.RFC3339NanoFixed), line)
 		}
 		if i%2 == 0 && stderr {
 			fmt.Fprintln(errStream, line)

--- a/examples/events.go
+++ b/examples/events.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/samalba/dockerclient"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/samalba/dockerclient"
 )
 
 func eventCallback(e *dockerclient.Event, ec chan error, args ...interface{}) {

--- a/examples/stats/stats.go
+++ b/examples/stats/stats.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/samalba/dockerclient"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/samalba/dockerclient"
 )
 
 func statCallback(id string, stat *dockerclient.Stats, ec chan error, args ...interface{}) {

--- a/types.go
+++ b/types.go
@@ -142,11 +142,11 @@ type AttachOptions struct {
 }
 
 type MonitorEventsFilters struct {
-	Event        string `json:",omitempty"`
+	Event      string   `json:",omitempty"`
 	Events     []string `json:",omitempty"`
-	Image        string `json:",omitempty"`
+	Image      string   `json:",omitempty"`
 	Images     []string `json:",omitempty"`
-	Container    string `json:",omitempty"`
+	Container  string   `json:",omitempty"`
 	Containers []string `json:",omitempty"`
 }
 


### PR DESCRIPTION
The latest package `github.com/docker/docker` does not contain jsonlog any more.

This package is used in test only, there is no harm to upgrade the package.